### PR TITLE
K66F support

### DIFF
--- a/configs/6lowpan_Atmel_RF.json
+++ b/configs/6lowpan_Atmel_RF.json
@@ -77,6 +77,9 @@
             "SERIAL_RX": "PTE1",
             "SERIAL_CTS": "PTE2",
             "SERIAL_RTS": "PTE3"
+        },
+        "K66F": {
+            "LED": "LED_GREEN"
         }
     }
 }

--- a/configs/6lowpan_Spirit1_RF.json
+++ b/configs/6lowpan_Spirit1_RF.json
@@ -78,6 +78,9 @@
     	    "SERIAL_RX": "SERIAL_RX",
     	    "SERIAL_CTS": "PD_11",
     	    "SERIAL_RTS": "PD_12"
+        },
+        "K66F": {
+            "LED": "LED_GREEN"
         }
     },
     "macros": ["PB5_ETH_PATCH"]

--- a/configs/Thread_Atmel_RF.json
+++ b/configs/Thread_Atmel_RF.json
@@ -59,6 +59,9 @@
             "SERIAL_RX": "PTE1",
             "SERIAL_CTS": "PTE2",
             "SERIAL_RTS": "PTE3"
+        },
+        "K66F": {
+            "LED": "LED_GREEN"
         }
     }
 }

--- a/configs/Thread_SLIP_Atmel_RF.json
+++ b/configs/Thread_SLIP_Atmel_RF.json
@@ -61,6 +61,9 @@
             "SERIAL_RX": "PTE1",
             "SERIAL_CTS": "PTE2",
             "SERIAL_RTS": "PTE3"
+        },
+        "K66F": {
+            "LED": "LED_GREEN"
         }
     }
 }

--- a/drivers/TARGET_K64F/sal-nanostack-driver-k64f-eth.lib
+++ b/drivers/TARGET_K64F/sal-nanostack-driver-k64f-eth.lib
@@ -1,1 +1,0 @@
-https://github.com/ARMmbed/sal-nanostack-driver-k64f-eth/#dafa84646b48287273c57d0f677ccc39e33c4cb3

--- a/drivers/TARGET_MCUXpresso_MCUS/sal-nanostack-driver-k64f-eth.lib
+++ b/drivers/TARGET_MCUXpresso_MCUS/sal-nanostack-driver-k64f-eth.lib
@@ -1,0 +1,1 @@
+https://github.com/ARMmbed/sal-nanostack-driver-k64f-eth/#ee7e8a9a2122415d45b93eb8e1abdc933b1a9c97

--- a/mbed_app.json
+++ b/mbed_app.json
@@ -77,6 +77,9 @@
             "SERIAL_RX": "PTE1",
             "SERIAL_CTS": "PTE2",
             "SERIAL_RTS": "PTE3"
+        },
+        "K66F": {
+            "LED": "LED_GREEN"
         }
     }
 }

--- a/source/border_router_main.cpp
+++ b/source/border_router_main.cpp
@@ -125,7 +125,9 @@ int main(int argc, char **argv)
     #error "MAC address not defined"
 #endif
 
-    led_ticker.attach_us(toggle_led1, 500000);
+    if (MBED_CONF_APP_LED != NC) {
+        led_ticker.attach_us(toggle_led1, 500000);
+    }
     border_router_start();
 }
 


### PR DESCRIPTION
Add support to NXP K66F board.

Required driver change already pushed in: https://github.com/ARMmbed/sal-nanostack-driver-k64f-eth/commit/ee7e8a9a2122415d45b93eb8e1abdc933b1a9c97
