### PR TITLE
Rename border_router_start() to border_router_tasklet_start()

### DIFF
--- a/source/border_router_main.cpp
+++ b/source/border_router_main.cpp
@@ -128,7 +128,7 @@ int main(int argc, char **argv)
     if (MBED_CONF_APP_LED != NC) {
         led_ticker.attach_us(toggle_led1, 500000);
     }
-    border_router_start();
+    border_router_tasklet_start();
 }
 
 /**

--- a/source/borderrouter_tasklet.c
+++ b/source/borderrouter_tasklet.c
@@ -115,7 +115,7 @@ static void start_6lowpan(const uint8_t *backhaul_address);
 static int8_t rf_interface_init(void);
 static void load_config(void);
 
-void border_router_start(void)
+void border_router_tasklet_start(void)
 {
     load_config();
     net_init_core();

--- a/source/borderrouter_tasklet.h
+++ b/source/borderrouter_tasklet.h
@@ -20,7 +20,7 @@ void backhaul_driver_init(void (*backhaul_driver_status_cb)(uint8_t, int8_t));
  * Initializes the border router module: loads configuration and
  * initiates bootstrap for the RF 6LoWPAN and backhaul interfaces.
  */
-void border_router_start(void);
+void border_router_tasklet_start(void);
 
 #ifdef __cplusplus
 }

--- a/source/borderrouter_thread_tasklet.c
+++ b/source/borderrouter_thread_tasklet.c
@@ -366,7 +366,7 @@ void thread_rf_init()
     }
 }
 
-void border_router_start(void)
+void border_router_tasklet_start(void)
 {
     net_init_core();
     thread_rf_init();


### PR DESCRIPTION
This is to prevent API collision with internal Nanostack API
when compiling against sources of Nanostack.