### PR TITLE
Enable PSK security mode by default

### DIFF
--- a/configs/6lowpan_Atmel_RF.json
+++ b/configs/6lowpan_Atmel_RF.json
@@ -29,7 +29,7 @@
         "slip_serial_baud_rate": "921600",
         "debug-trace": "false",
         "defined-BR-config": "true",
-        "security-mode": "NONE",
+        "security-mode": "PSK",
         "psk-key-id": 1,
         "psk-key": "{0xa0, 0xa1, 0xa2, 0xa3, 0xa4, 0xa5, 0xa6, 0xa7, 0xa8, 0xa9, 0xaa, 0xab, 0xac, 0xad, 0xae, 0xaf}",
         "pana-mode": "",


### PR DESCRIPTION
During 1.2.2EA OOB, we've found out that the Cloud Client end-node doesn't connect to the BR, unless PSK mode is enabled.
This has to be enabled by default.

@SeppoTakalo @yogpan01 @JanneKiiskila @ashok-rao 