### PR TITLE
ONME-3153: Support long addresses

### DIFF
--- a/source/borderrouter_tasklet.c
+++ b/source/borderrouter_tasklet.c
@@ -211,9 +211,14 @@ static void load_config(void)
 
     /* generate DODAG ID */
     memcpy(rpl_setup_info.DODAG_ID, nd_prefix, 8);
-    memcpy(&rpl_setup_info.DODAG_ID[8], gp16_address_suffix, 6);
-    rpl_setup_info.DODAG_ID[14] = (br.mac_short_adr >> 8);
-    rpl_setup_info.DODAG_ID[15] = br.mac_short_adr;
+    if (br.mac_short_adr < 0xfffe) {
+        memcpy(&rpl_setup_info.DODAG_ID[8], gp16_address_suffix, 6);
+        rpl_setup_info.DODAG_ID[14] = (br.mac_short_adr >> 8);
+        rpl_setup_info.DODAG_ID[15] = br.mac_short_adr;
+    } else {
+        rf_read_mac_address(&rpl_setup_info.DODAG_ID[8]);
+        rpl_setup_info.DODAG_ID[8] ^= 2;
+    }
 
     /* DODAG configuration */
     dodag_config.DAG_DIO_INT_DOUB = cfg_int(global_config, "RPL_IDOUBLINGS", 12);

--- a/source/borderrouter_tasklet.c
+++ b/source/borderrouter_tasklet.c
@@ -117,10 +117,11 @@ static void load_config(void);
 
 void border_router_tasklet_start(void)
 {
-    load_config();
     net_init_core();
     /* initialize Radio module*/
     net_6lowpan_id = rf_interface_init();
+
+    load_config();
 
     protocol_stats_start(&nwk_stats);
 


### PR DESCRIPTION
Support for long GP64 addresses instead of default GP16.
Note: This does not affect nodes, which needs also to choose addressing
mode.