### PR TITLE
Realign default mbed_app.json with 6lowpan_Atmel_RF.json

### DIFF
--- a/mbed_app.json
+++ b/mbed_app.json
@@ -20,6 +20,10 @@
             "help": "Where to get EUI48 address. Options are BOARD, CONFIG",
             "value": "BOARD"
         },
+        "backhaul-mld": {
+            "help": "Enable proxying Multicast Listener Discovery messages to backhaul network",
+            "value": "false"
+        },
         "backhaul-mac": "{0x02, 0x00, 0x00, 0x00, 0x00, 0x01}",
         "slip_hw_flow_control": "false",
         "slip_serial_baud_rate": "921600",


### PR DESCRIPTION
New option was added to the configs JSONs, but not the default. As long as it's there, it should match 6lowpan_Atmel_RF.json. (But see #79)