### PR TITLE
Add support for EMAC backhaul driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,6 @@ driver can be used, or a native Nanostack driver. Currently, there are Nanostack
 for the following backhauls:
 
 * [K64F Ethernet](https://github.com/ARMmbed/sal-nanostack-driver-k64f-eth)
-* [NUCLEO_F429ZI Ethernet](https://github.com/ARMmbed/sal-nanostack-driver-stm32-eth)
 * [SLIP driver](https://github.com/ARMmbed/sal-stack-nanostack-slip)
 
 The existing drivers are found in the `drivers/` folder. More drivers can be linked in.

--- a/README.md
+++ b/README.md
@@ -51,18 +51,20 @@ The target platform is the hardware on which the border router runs. There are n
 
 If you wish to write your own target, follow the instructions in [Adding target support to mbed OS 5](https://docs.mbed.com/docs/mbed-os-handbook/en/latest/advanced/porting_guide/).
 
-The border router requires backhaul and RF drivers to be provided for Nanostack. The backhaul is either SLIP or Ethernet. Currently, there are drivers for the following backhauls:
-
-* [K64F Ethernet](https://github.com/ARMmbed/sal-nanostack-driver-k64f-eth)
-* [NUCLEO_F429ZI Ethernet](https://github.com/ARMmbed/sal-nanostack-driver-stm32-eth)
-* [SLIP driver](https://github.com/ARMmbed/sal-stack-nanostack-slip)
-
-And following RF drivers:
+The border router requires an RF driver to be provided for Nanostack. Currently, there are the following drivers:
 
 * [Atmel AT86RF233](https://github.com/ARMmbed/atmel-rf-driver)
 * [Atmel AT86RF212B](https://github.com/ARMmbed/atmel-rf-driver)
 * [STM Spirit1](https://github.com/ARMmbed/stm-spirit1-rf-driver)
 * [NXP MCR20A](https://github.com/ARMmbed/mcr20a-rf-driver)
+
+The backhaul is either SLIP or Ethernet. For Ethernet either an mbed OS "EMAC"
+driver can be used, or a native Nanostack driver. Currently, there are Nanostack drivers
+for the following backhauls:
+
+* [K64F Ethernet](https://github.com/ARMmbed/sal-nanostack-driver-k64f-eth)
+* [NUCLEO_F429ZI Ethernet](https://github.com/ARMmbed/sal-nanostack-driver-stm32-eth)
+* [SLIP driver](https://github.com/ARMmbed/sal-stack-nanostack-slip)
 
 The existing drivers are found in the `drivers/` folder. More drivers can be linked in.
 
@@ -148,7 +150,7 @@ The Nanostack border router application can be connected to a backhaul network. 
 ```
 "config": {
     "backhaul-driver": {
-        "help": "options are ETH, SLIP",
+        "help": "options are ETH, SLIP, EMAC",
         "value": "ETH"
     },
     "backhaul-mac-src": {
@@ -164,7 +166,9 @@ The Nanostack border router application can be connected to a backhaul network. 
 }
 ```
 
-You can select your preferred option through the configuration file (field `backhaul-driver` in the `config` section). The value `SLIP` includes the SLIP driver, while the value `ETH` compiles the border router application with Ethernet backhaul support. You can define the MAC address on the backhaul interface manually (field `backhaul-mac-src` value `CONFIG`). Alternatively, you can use the MAC address provided by the development board (field `backhaul-mac-src` value `BOARD`). By default, the backhaul driver is set to `ETH` and the MAC address source is `BOARD`.
+You can select your preferred option through the configuration file (field `backhaul-driver` in the `config` section). The value `SLIP` includes the SLIP driver, while the value `ETH` compiles the border router application with Nanostack native Ethernet backhaul support. `EMAC` uses the board's default mbed OS network driver, which must be EMAC-based (derived from EMACInterface).
+
+You can define the MAC address on the backhaul interface manually (field `backhaul-mac-src` value `CONFIG`). Alternatively, you can use the MAC address provided by the development board (field `backhaul-mac-src` value `BOARD`). By default, the backhaul driver is set to `ETH` and the MAC address source is `BOARD`.
 
 You can also set the backhaul bootstrap mode (field `backhaul-dynamic-bootstrap`). By default, the bootstrap mode is set to true, which means the autonomous mode. With the autonomous mode, the border router learns the prefix information automatically from an IPv6 gateway in the Ethernet/SLIP segment. When the parameter is set to false, it enables you to set up a manual configuration of `backhaul-prefix` and `backhaul-default-route`.
 
@@ -192,6 +196,14 @@ An example configuration for the SLIP driver:
         "SERIAL_RTS": "PTE3"
     }
 ```
+
+#### Note on EMAC backhaul
+
+When `backhaul_driver` is set to `EMAC`, the border router will use the target's default network driver, as supplied by `NetworkInterface::get_default_instance`. This must be EMAC-based, derived from EMACInterface. If th - the same driver that a default-constructed `EthernetInterface` would use, so in principle it should work on any board where `EthernetInterface` works.
+
+To use a different interface, change the setting of `target.default-network-interface-type` in `mbed_app.json` to point to a different interface type, or add an overriding definition of `NetworkInterface::get_default_instance` to the application - this will override any default supplied by the target board.
+
+To use Wi-Fi or other more complex EMAC drivers, necessary configuration parameters must be supplied, either via `mbed_app.json` or configuration in the `NetworkInterface::get_default_instance` override. Also, the driver must follow the guidelines of `EMACInterface` - the border router does not call the `EMACInterface`'s `connect` method, so the driver must work with only a `powerup` call to the `EMAC`.
 
 ### Switching the RF shield
 

--- a/configs/6lowpan_Atmel_RF.json
+++ b/configs/6lowpan_Atmel_RF.json
@@ -10,7 +10,7 @@
         },
         "backhaul-driver": {
             "help": "options are ETH, SLIP, EMAC",
-            "value": "ETH"
+            "value": "EMAC"
         },
         "mesh-mode": {
             "help": "Mesh networking mode. Options are LOWPAN_ND and THREAD",

--- a/configs/6lowpan_Atmel_RF.json
+++ b/configs/6lowpan_Atmel_RF.json
@@ -9,7 +9,7 @@
             "value": "ATMEL"
         },
         "backhaul-driver": {
-            "help": "options are ETH, SLIP",
+            "help": "options are ETH, SLIP, EMAC",
             "value": "ETH"
         },
         "mesh-mode": {
@@ -70,6 +70,8 @@
         "*": {
             "target.features_add": ["NANOSTACK", "LOWPAN_BORDER_ROUTER", "COMMON_PAL"],
             "target.features_remove": ["LWIP"],
+            "target.network-default-interface-type": "ETHERNET",
+            "nsapi.default-stack": "NANOSTACK",
             "mbed-trace.enable": 1,
             "nanostack.configuration": "lowpan_border_router",
             "platform.stdio-convert-newlines": true,

--- a/configs/6lowpan_Atmel_RF.json
+++ b/configs/6lowpan_Atmel_RF.json
@@ -2,7 +2,7 @@
     "config": {
         "heap-size": {
              "help": "The amount of static RAM to reserve for nsdynmemlib heap",
-             "value": 50000
+             "value": 40000
         },
         "radio-type":{
             "help": "options are ATMEL, MCR20, SPIRIT1",

--- a/configs/6lowpan_Spirit1_RF.json
+++ b/configs/6lowpan_Spirit1_RF.json
@@ -10,7 +10,7 @@
         },
         "backhaul-driver": {
             "help": "options are ETH, SLIP, EMAC",
-            "value": "ETH"
+            "value": "EMAC"
         },
         "mesh-mode": {
             "help": "Mesh networking mode. Options are LOWPAN_ND and THREAD",

--- a/configs/6lowpan_Spirit1_RF.json
+++ b/configs/6lowpan_Spirit1_RF.json
@@ -9,7 +9,7 @@
             "value": "SPIRIT1"
         },
         "backhaul-driver": {
-            "help": "options are ETH, SLIP",
+            "help": "options are ETH, SLIP, EMAC",
             "value": "ETH"
         },
         "mesh-mode": {
@@ -71,6 +71,8 @@
             "target.features_add": ["NANOSTACK", "LOWPAN_BORDER_ROUTER", "COMMON_PAL"],
             "target.features_remove": ["LWIP"],
             "spirit1.mac-address": "{0xf0, 0xf1, 0xf2, 0xf3, 0xf4, 0xf5, 0xf6, 0xf7}",
+            "target.network-default-interface-type": "ETHERNET",
+            "nsapi.default-stack": "NANOSTACK",
             "mbed-trace.enable": 1,
             "nanostack.configuration": "lowpan_border_router",
             "platform.stdio-convert-newlines": true,

--- a/configs/6lowpan_Spirit1_RF.json
+++ b/configs/6lowpan_Spirit1_RF.json
@@ -2,7 +2,7 @@
     "config": {
         "heap-size": {
              "help": "The amount of static RAM to reserve for nsdynmemlib heap",
-             "value": 50000
+             "value": 40000
         },
         "radio-type":{
             "help": "options are ATMEL, MCR20, SPIRIT1",

--- a/configs/Thread_Atmel_RF.json
+++ b/configs/Thread_Atmel_RF.json
@@ -10,7 +10,7 @@
         },
         "backhaul-driver": {
             "help": "options are ETH, SLIP, EMAC",
-            "value": "ETH"
+            "value": "EMAC"
         },
         "mesh-mode": {
             "help": "Mesh networking mode. Options are LOWPAN_ND and THREAD",

--- a/configs/Thread_Atmel_RF.json
+++ b/configs/Thread_Atmel_RF.json
@@ -9,7 +9,7 @@
             "value": "ATMEL"
         },
         "backhaul-driver": {
-            "help": "options are ETH, SLIP",
+            "help": "options are ETH, SLIP, EMAC",
             "value": "ETH"
         },
         "mesh-mode": {
@@ -54,6 +54,8 @@
         "*": {
             "target.features_add": ["NANOSTACK", "COMMON_PAL", "THREAD_BORDER_ROUTER"],
             "target.features_remove": ["LWIP"],
+            "target.network-default-interface-type": "ETHERNET",
+            "nsapi.default-stack": "NANOSTACK",
             "mbed-trace.enable": 1,
             "nanostack.configuration": "thread_border_router",
             "platform.stdio-convert-newlines": true,

--- a/configs/Thread_Atmel_RF.json
+++ b/configs/Thread_Atmel_RF.json
@@ -2,7 +2,7 @@
     "config": {
         "heap-size": {
              "help": "The amount of static RAM to reserve for nsdynmemlib heap",
-             "value": 50000
+             "value": 40000
         },
         "radio-type":{
             "help": "options are ATMEL, MCR20",

--- a/configs/Thread_SLIP_Atmel_RF.json
+++ b/configs/Thread_SLIP_Atmel_RF.json
@@ -2,7 +2,7 @@
     "config": {
         "heap-size": {
              "help": "The amount of static RAM to reserve for nsdynmemlib heap",
-             "value": 50000
+             "value": 40000
         },
         "radio-type":{
             "help": "options are ATMEL, MCR20",

--- a/configs/Thread_SLIP_Atmel_RF.json
+++ b/configs/Thread_SLIP_Atmel_RF.json
@@ -9,7 +9,7 @@
             "value": "ATMEL"
         },
         "backhaul-driver": {
-            "help": "options are ETH, SLIP",
+            "help": "options are ETH, SLIP, EMAC",
             "value": "SLIP"
         },
         "mesh-mode": {
@@ -56,6 +56,8 @@
         "*": {
             "target.features_add": ["NANOSTACK", "COMMON_PAL", "THREAD_BORDER_ROUTER"],
             "target.features_remove": ["LWIP"],
+            "target.network-default-interface-type": "ETHERNET",
+            "nsapi.default-stack": "NANOSTACK",
             "mbed-trace.enable": 1,
             "nanostack.configuration": "thread_border_router",
             "platform.stdio-convert-newlines": true,

--- a/drivers/TARGET_NUCLEO_F429ZI/sal-nanostack-driver-stm32-eth.lib
+++ b/drivers/TARGET_NUCLEO_F429ZI/sal-nanostack-driver-stm32-eth.lib
@@ -1,1 +1,0 @@
-https://github.com/ARMmbed/sal-nanostack-driver-stm32-eth/#1369c4a6a4546ca8ce8e51d7827621db2a2ad3c7

--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#367dbdf5145f4d6aa3e483c147fe7bda1ce23a36
+https://github.com/ARMmbed/mbed-os/#6817dc43f9f5216cbe077059fc561fa89a766dc9

--- a/mbed_app.json
+++ b/mbed_app.json
@@ -10,7 +10,7 @@
         },
         "backhaul-driver": {
             "help": "options are ETH, SLIP, EMAC",
-            "value": "ETH"
+            "value": "EMAC"
         },
         "mesh-mode": {
             "help": "Mesh networking mode. Options are LOWPAN_ND and THREAD",

--- a/mbed_app.json
+++ b/mbed_app.json
@@ -9,7 +9,7 @@
             "value": "ATMEL"
         },
         "backhaul-driver": {
-            "help": "options are ETH, SLIP",
+            "help": "options are ETH, SLIP, EMAC",
             "value": "ETH"
         },
         "mesh-mode": {
@@ -66,6 +66,8 @@
         "*": {
             "target.features_add": ["NANOSTACK", "LOWPAN_BORDER_ROUTER", "COMMON_PAL"],
             "target.features_remove": ["LWIP"],
+            "target.network-default-interface-type": "ETHERNET",
+            "nsapi.default-stack": "NANOSTACK",
             "mbed-trace.enable": 1,
             "nanostack.configuration": "lowpan_border_router",
             "platform.stdio-convert-newlines": true,

--- a/mbed_app.json
+++ b/mbed_app.json
@@ -2,7 +2,7 @@
     "config": {
         "heap-size": {
              "help": "The amount of static RAM to reserve for nsdynmemlib heap",
-             "value": 50000
+             "value": 40000
         },
         "radio-type":{
             "help": "options are ATMEL, MCR20, SPIRIT1",

--- a/source/borderrouter_tasklet.c
+++ b/source/borderrouter_tasklet.c
@@ -117,7 +117,6 @@ static void load_config(void);
 
 void border_router_tasklet_start(void)
 {
-    net_init_core();
     /* initialize Radio module*/
     net_6lowpan_id = rf_interface_init();
 

--- a/source/borderrouter_thread_tasklet.c
+++ b/source/borderrouter_thread_tasklet.c
@@ -373,7 +373,6 @@ void thread_rf_init()
 
 void border_router_tasklet_start(void)
 {
-    net_init_core();
     thread_rf_init();
     protocol_stats_start(&nwk_stats);
 


### PR DESCRIPTION
Add new EMAC backhaul driver option that uses new mbed OS 5.9 EMAC and default network interface APIs. This should work for any Ethernet EMAC driver, and can work with appropriately-engineered Wifi drivers - see README.md for more details.

