### PR TITLE
Fixed macro format to match regular expression

### DIFF
--- a/configs/Thread_SLIP_Atmel_RF.json
+++ b/configs/Thread_SLIP_Atmel_RF.json
@@ -50,7 +50,7 @@
         "SERIAL_CTS": "NC",
         "SERIAL_RTS": "NC"
     },
-    "macros": ["MBEDTLS_USER_CONFIG_FILE=\"source/mbedtls_thread_config.h\"", "ATMEL_SPI_RST = PTD4"],
+    "macros": ["MBEDTLS_USER_CONFIG_FILE=\"source/mbedtls_thread_config.h\"", "ATMEL_SPI_RST=PTD4"],
     "target_overrides": {
         "*": {
             "target.features_add": ["NANOSTACK", "COMMON_PAL", "THREAD_BORDER_ROUTER"],


### PR DESCRIPTION
Compile failed because the macro did not match the regular expression used to parse macros.