### PR TITLE
Increase Nanostack heap size for Thread BR

### DIFF
--- a/configs/Thread_Atmel_RF.json
+++ b/configs/Thread_Atmel_RF.json
@@ -2,7 +2,7 @@
     "config": {
         "heap-size": {
              "help": "The amount of static RAM to reserve for nsdynmemlib heap",
-             "value": 40000
+             "value": 65535
         },
         "radio-type":{
             "help": "options are ATMEL, MCR20",

--- a/configs/Thread_SLIP_Atmel_RF.json
+++ b/configs/Thread_SLIP_Atmel_RF.json
@@ -2,7 +2,7 @@
     "config": {
         "heap-size": {
              "help": "The amount of static RAM to reserve for nsdynmemlib heap",
-             "value": 40000
+             "value": 65535
         },
         "radio-type":{
             "help": "options are ATMEL, MCR20",


### PR DESCRIPTION
Thread BR requires 45k of heap to start properly.
Increase heap size from 40k to 64k.

Note: Thread will not compile with IAR.