### PR TITLE
Revert support for EMAC backhaul driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,19 +51,18 @@ The target platform is the hardware on which the border router runs. There are n
 
 If you wish to write your own target, follow the instructions in [Adding target support to mbed OS 5](https://docs.mbed.com/docs/mbed-os-handbook/en/latest/advanced/porting_guide/).
 
-The border router requires an RF driver to be provided for Nanostack. Currently, there are the following drivers:
+The border router requires backhaul and RF drivers to be provided for Nanostack. The backhaul is either SLIP or Ethernet. Currently, there are drivers for the following backhauls:
+
+* [K64F Ethernet](https://github.com/ARMmbed/sal-nanostack-driver-k64f-eth)
+* [NUCLEO_F429ZI Ethernet](https://github.com/ARMmbed/sal-nanostack-driver-stm32-eth)
+* [SLIP driver](https://github.com/ARMmbed/sal-stack-nanostack-slip)
+
+And following RF drivers:
 
 * [Atmel AT86RF233](https://github.com/ARMmbed/atmel-rf-driver)
 * [Atmel AT86RF212B](https://github.com/ARMmbed/atmel-rf-driver)
 * [STM Spirit1](https://github.com/ARMmbed/stm-spirit1-rf-driver)
 * [NXP MCR20A](https://github.com/ARMmbed/mcr20a-rf-driver)
-
-The backhaul is either SLIP or Ethernet. For Ethernet either an mbed OS "EMAC"
-driver can be used, or a native Nanostack driver. Currently, there are Nanostack drivers
-for the following backhauls:
-
-* [K64F Ethernet](https://github.com/ARMmbed/sal-nanostack-driver-k64f-eth)
-* [SLIP driver](https://github.com/ARMmbed/sal-stack-nanostack-slip)
 
 The existing drivers are found in the `drivers/` folder. More drivers can be linked in.
 
@@ -149,7 +148,7 @@ The Nanostack border router application can be connected to a backhaul network. 
 ```
 "config": {
     "backhaul-driver": {
-        "help": "options are ETH, SLIP, EMAC",
+        "help": "options are ETH, SLIP",
         "value": "ETH"
     },
     "backhaul-mac-src": {
@@ -165,9 +164,7 @@ The Nanostack border router application can be connected to a backhaul network. 
 }
 ```
 
-You can select your preferred option through the configuration file (field `backhaul-driver` in the `config` section). The value `SLIP` includes the SLIP driver, while the value `ETH` compiles the border router application with Nanostack native Ethernet backhaul support. `EMAC` uses the board's default mbed OS network driver, which must be EMAC-based (derived from EMACInterface).
-
-You can define the MAC address on the backhaul interface manually (field `backhaul-mac-src` value `CONFIG`). Alternatively, you can use the MAC address provided by the development board (field `backhaul-mac-src` value `BOARD`). By default, the backhaul driver is set to `ETH` and the MAC address source is `BOARD`.
+You can select your preferred option through the configuration file (field `backhaul-driver` in the `config` section). The value `SLIP` includes the SLIP driver, while the value `ETH` compiles the border router application with Ethernet backhaul support. You can define the MAC address on the backhaul interface manually (field `backhaul-mac-src` value `CONFIG`). Alternatively, you can use the MAC address provided by the development board (field `backhaul-mac-src` value `BOARD`). By default, the backhaul driver is set to `ETH` and the MAC address source is `BOARD`.
 
 You can also set the backhaul bootstrap mode (field `backhaul-dynamic-bootstrap`). By default, the bootstrap mode is set to true, which means the autonomous mode. With the autonomous mode, the border router learns the prefix information automatically from an IPv6 gateway in the Ethernet/SLIP segment. When the parameter is set to false, it enables you to set up a manual configuration of `backhaul-prefix` and `backhaul-default-route`.
 
@@ -195,14 +192,6 @@ An example configuration for the SLIP driver:
         "SERIAL_RTS": "PTE3"
     }
 ```
-
-#### Note on EMAC backhaul
-
-When `backhaul_driver` is set to `EMAC`, the border router will use the target's default network driver, as supplied by `NetworkInterface::get_default_instance`. This must be EMAC-based, derived from EMACInterface. If th - the same driver that a default-constructed `EthernetInterface` would use, so in principle it should work on any board where `EthernetInterface` works.
-
-To use a different interface, change the setting of `target.default-network-interface-type` in `mbed_app.json` to point to a different interface type, or add an overriding definition of `NetworkInterface::get_default_instance` to the application - this will override any default supplied by the target board.
-
-To use Wi-Fi or other more complex EMAC drivers, necessary configuration parameters must be supplied, either via `mbed_app.json` or configuration in the `NetworkInterface::get_default_instance` override. Also, the driver must follow the guidelines of `EMACInterface` - the border router does not call the `EMACInterface`'s `connect` method, so the driver must work with only a `powerup` call to the `EMAC`.
 
 ### Switching the RF shield
 

--- a/configs/6lowpan_Atmel_RF.json
+++ b/configs/6lowpan_Atmel_RF.json
@@ -2,15 +2,15 @@
     "config": {
         "heap-size": {
              "help": "The amount of static RAM to reserve for nsdynmemlib heap",
-             "value": 40000
+             "value": 50000
         },
         "radio-type":{
             "help": "options are ATMEL, MCR20, SPIRIT1",
             "value": "ATMEL"
         },
         "backhaul-driver": {
-            "help": "options are ETH, SLIP, EMAC",
-            "value": "EMAC"
+            "help": "options are ETH, SLIP",
+            "value": "ETH"
         },
         "mesh-mode": {
             "help": "Mesh networking mode. Options are LOWPAN_ND and THREAD",
@@ -70,8 +70,6 @@
         "*": {
             "target.features_add": ["NANOSTACK", "LOWPAN_BORDER_ROUTER", "COMMON_PAL"],
             "target.features_remove": ["LWIP"],
-            "target.network-default-interface-type": "ETHERNET",
-            "nsapi.default-stack": "NANOSTACK",
             "mbed-trace.enable": 1,
             "nanostack.configuration": "lowpan_border_router",
             "platform.stdio-convert-newlines": true,

--- a/configs/6lowpan_Spirit1_RF.json
+++ b/configs/6lowpan_Spirit1_RF.json
@@ -2,15 +2,15 @@
     "config": {
         "heap-size": {
              "help": "The amount of static RAM to reserve for nsdynmemlib heap",
-             "value": 40000
+             "value": 50000
         },
         "radio-type":{
             "help": "options are ATMEL, MCR20, SPIRIT1",
             "value": "SPIRIT1"
         },
         "backhaul-driver": {
-            "help": "options are ETH, SLIP, EMAC",
-            "value": "EMAC"
+            "help": "options are ETH, SLIP",
+            "value": "ETH"
         },
         "mesh-mode": {
             "help": "Mesh networking mode. Options are LOWPAN_ND and THREAD",
@@ -71,8 +71,6 @@
             "target.features_add": ["NANOSTACK", "LOWPAN_BORDER_ROUTER", "COMMON_PAL"],
             "target.features_remove": ["LWIP"],
             "spirit1.mac-address": "{0xf0, 0xf1, 0xf2, 0xf3, 0xf4, 0xf5, 0xf6, 0xf7}",
-            "target.network-default-interface-type": "ETHERNET",
-            "nsapi.default-stack": "NANOSTACK",
             "mbed-trace.enable": 1,
             "nanostack.configuration": "lowpan_border_router",
             "platform.stdio-convert-newlines": true,

--- a/configs/Thread_Atmel_RF.json
+++ b/configs/Thread_Atmel_RF.json
@@ -2,15 +2,15 @@
     "config": {
         "heap-size": {
              "help": "The amount of static RAM to reserve for nsdynmemlib heap",
-             "value": 65535
+             "value": 50000
         },
         "radio-type":{
             "help": "options are ATMEL, MCR20",
             "value": "ATMEL"
         },
         "backhaul-driver": {
-            "help": "options are ETH, SLIP, EMAC",
-            "value": "EMAC"
+            "help": "options are ETH, SLIP",
+            "value": "ETH"
         },
         "mesh-mode": {
             "help": "Mesh networking mode. Options are LOWPAN_ND and THREAD",
@@ -54,8 +54,6 @@
         "*": {
             "target.features_add": ["NANOSTACK", "COMMON_PAL", "THREAD_BORDER_ROUTER"],
             "target.features_remove": ["LWIP"],
-            "target.network-default-interface-type": "ETHERNET",
-            "nsapi.default-stack": "NANOSTACK",
             "mbed-trace.enable": 1,
             "nanostack.configuration": "thread_border_router",
             "platform.stdio-convert-newlines": true,

--- a/configs/Thread_SLIP_Atmel_RF.json
+++ b/configs/Thread_SLIP_Atmel_RF.json
@@ -2,14 +2,14 @@
     "config": {
         "heap-size": {
              "help": "The amount of static RAM to reserve for nsdynmemlib heap",
-             "value": 65535
+             "value": 50000
         },
         "radio-type":{
             "help": "options are ATMEL, MCR20",
             "value": "ATMEL"
         },
         "backhaul-driver": {
-            "help": "options are ETH, SLIP, EMAC",
+            "help": "options are ETH, SLIP",
             "value": "SLIP"
         },
         "mesh-mode": {
@@ -56,8 +56,6 @@
         "*": {
             "target.features_add": ["NANOSTACK", "COMMON_PAL", "THREAD_BORDER_ROUTER"],
             "target.features_remove": ["LWIP"],
-            "target.network-default-interface-type": "ETHERNET",
-            "nsapi.default-stack": "NANOSTACK",
             "mbed-trace.enable": 1,
             "nanostack.configuration": "thread_border_router",
             "platform.stdio-convert-newlines": true,

--- a/drivers/TARGET_NUCLEO_F429ZI/sal-nanostack-driver-stm32-eth.lib
+++ b/drivers/TARGET_NUCLEO_F429ZI/sal-nanostack-driver-stm32-eth.lib
@@ -1,0 +1,1 @@
+https://github.com/ARMmbed/sal-nanostack-driver-stm32-eth/#1369c4a6a4546ca8ce8e51d7827621db2a2ad3c7

--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#6817dc43f9f5216cbe077059fc561fa89a766dc9
+https://github.com/ARMmbed/mbed-os/#367dbdf5145f4d6aa3e483c147fe7bda1ce23a36

--- a/mbed_app.json
+++ b/mbed_app.json
@@ -2,15 +2,15 @@
     "config": {
         "heap-size": {
              "help": "The amount of static RAM to reserve for nsdynmemlib heap",
-             "value": 40000
+             "value": 50000
         },
         "radio-type":{
             "help": "options are ATMEL, MCR20, SPIRIT1",
             "value": "ATMEL"
         },
         "backhaul-driver": {
-            "help": "options are ETH, SLIP, EMAC",
-            "value": "EMAC"
+            "help": "options are ETH, SLIP",
+            "value": "ETH"
         },
         "mesh-mode": {
             "help": "Mesh networking mode. Options are LOWPAN_ND and THREAD",
@@ -66,8 +66,6 @@
         "*": {
             "target.features_add": ["NANOSTACK", "LOWPAN_BORDER_ROUTER", "COMMON_PAL"],
             "target.features_remove": ["LWIP"],
-            "target.network-default-interface-type": "ETHERNET",
-            "nsapi.default-stack": "NANOSTACK",
             "mbed-trace.enable": 1,
             "nanostack.configuration": "lowpan_border_router",
             "platform.stdio-convert-newlines": true,

--- a/source/border_router_main.cpp
+++ b/source/border_router_main.cpp
@@ -10,12 +10,6 @@
 #include "drivers/eth_driver.h"
 #include "sal-stack-nanostack-slip/Slip.h"
 
-#include "Nanostack.h"
-#include "NanostackEthernetInterface.h"
-#include "MeshInterfaceNanostack.h"
-#include "EMACInterface.h"
-#include "EMAC.h"
-
 #ifdef  MBED_CONF_APP_DEBUG_TRACE
 #if MBED_CONF_APP_DEBUG_TRACE == 1
 #define APP_TRACE_LEVEL TRACE_ACTIVE_LEVEL_DEBUG
@@ -25,7 +19,6 @@
 #endif //MBED_CONF_APP_DEBUG_TRACE
 
 #include "ns_hal_init.h"
-#include "mesh_system.h"
 #include "cmsis_os.h"
 #include "arm_hal_interrupt.h"
 
@@ -35,17 +28,8 @@
 
 #define APP_DEFINED_HEAP_SIZE MBED_CONF_APP_HEAP_SIZE
 static uint8_t app_stack_heap[APP_DEFINED_HEAP_SIZE];
+static uint8_t mac[6] = {0};
 static mem_stat_t heap_info;
-
-#define BOARD 1
-#define CONFIG 2
-#if MBED_CONF_APP_BACKHAUL_MAC_SRC == BOARD
-static uint8_t mac[6];
-#elif MBED_CONF_APP_BACKHAUL_MAC_SRC == CONFIG
-static const uint8_t mac[] = MBED_CONF_APP_BACKHAUL_MAC;
-#else
-#error "MAC address not defined"
-#endif
 
 static DigitalOut led1(MBED_CONF_APP_LED);
 
@@ -66,23 +50,6 @@ static void trace_printer(const char *str)
     printf("%s\n", str);
 }
 
-#undef ETH
-#undef SLIP
-#undef EMAC
-#define ETH 1
-#define SLIP 2
-#define EMAC 3
-#if MBED_CONF_APP_BACKHAUL_DRIVER == EMAC
-static void (*emac_actual_cb)(uint8_t, int8_t);
-static int8_t emac_driver_id;
-static void emac_link_cb(bool up)
-{
-    if (emac_actual_cb) {
-        emac_actual_cb(up, emac_driver_id);
-    }
-}
-#endif
-
 /**
  * \brief Initializes the SLIP MAC backhaul driver.
  * This function is called by the border router module.
@@ -90,6 +57,8 @@ static void emac_link_cb(bool up)
 void backhaul_driver_init(void (*backhaul_driver_status_cb)(uint8_t, int8_t))
 {
 // Values allowed in "backhaul-driver" option
+#define ETH 0
+#define SLIP 1
 #if MBED_CONF_APP_BACKHAUL_DRIVER == SLIP
     SlipMACDriver *pslipmacdriver;
     int8_t slipdrv_id = -1;
@@ -118,37 +87,6 @@ void backhaul_driver_init(void (*backhaul_driver_status_cb)(uint8_t, int8_t))
     }
 
     tr_error("Backhaul driver init failed, retval = %d", slipdrv_id);
-#elif MBED_CONF_APP_BACKHAUL_DRIVER == EMAC
-#undef EMAC
-    tr_info("Using EMAC backhaul driver...");
-    NetworkInterface *net = NetworkInterface::get_default_instance();
-    if (!net) {
-        tr_error("Default network interface not found");
-        exit(1);
-    }
-    EMACInterface *emacif = net->emacInterface();
-    if (!emacif) {
-        tr_error("Default interface is not EMAC-based");
-        exit(1);
-    }
-    EMAC &emac = emacif->get_emac();
-    Nanostack::EthernetInterface *ns_if;
-#if MBED_CONF_APP_BACKHAUL_MAC_SRC == BOARD
-    /* Let the core code choose address - either from board or EMAC (for
-     * ETH and SLIP we pass in the board address already in mac[]) */
-    nsapi_error_t err = Nanostack::get_instance().add_ethernet_interface(emac, true, &ns_if);
-    /* Read back what they chose into our mac[] */
-    ns_if->get_mac_address(mac);
-#else
-    nsapi_error_t err = Nanostack::get_instance().add_ethernet_interface(emac, true, &ns_if, mac);
-#endif
-    if (err < 0) {
-        tr_error("Backhaul driver init failed, retval = %d", err);
-    } else {
-        emac_actual_cb = backhaul_driver_status_cb;
-        emac_driver_id = ns_if->get_driver_id();
-        emac.set_link_state_cb(emac_link_cb);
-    }
 #elif MBED_CONF_APP_BACKHAUL_DRIVER == ETH
     tr_info("Using ETH backhaul driver...");
     arm_eth_phy_device_register(mac, backhaul_driver_status_cb);
@@ -156,9 +94,7 @@ void backhaul_driver_init(void (*backhaul_driver_status_cb)(uint8_t, int8_t))
 #else
 #error "Unsupported backhaul driver"
 #endif
-#undef SLIP
-#undef ETH
-#undef EMAC
+
 }
 
 /**
@@ -174,12 +110,20 @@ int main(int argc, char **argv)
     mbed_trace_print_function_set(trace_printer);
     mbed_trace_config_set(TRACE_MODE_COLOR | APP_TRACE_LEVEL | TRACE_CARRIAGE_RETURN);
 
-    // Have to let mesh_system do net_init_core in case we use
-    // Nanostack::add_ethernet_interface()
-    mesh_system_init();
 
+#define BOARD 0
+#define CONFIG 1
 #if MBED_CONF_APP_BACKHAUL_MAC_SRC == BOARD
+    /* Setting the MAC Address from UID.
+     * Takes UID Mid low and UID low and shuffles them around. */
     mbed_mac_address((char *)mac);
+#elif MBED_CONF_APP_BACKHAUL_MAC_SRC == CONFIG
+    const uint8_t mac48[] = MBED_CONF_APP_BACKHAUL_MAC;
+    for (uint32_t i = 0; i < sizeof(mac); ++i) {
+        mac[i] = mac48[i];
+    }
+#else
+    #error "MAC address not defined"
 #endif
 
     if (MBED_CONF_APP_LED != NC) {

--- a/source/borderrouter_tasklet.c
+++ b/source/borderrouter_tasklet.c
@@ -117,6 +117,7 @@ static void load_config(void);
 
 void border_router_tasklet_start(void)
 {
+    net_init_core();
     /* initialize Radio module*/
     net_6lowpan_id = rf_interface_init();
 

--- a/source/borderrouter_thread_tasklet.c
+++ b/source/borderrouter_thread_tasklet.c
@@ -373,6 +373,7 @@ void thread_rf_init()
 
 void border_router_tasklet_start(void)
 {
+    net_init_core();
     thread_rf_init();
     protocol_stats_start(&nwk_stats);
 


### PR DESCRIPTION
Revert EMAC changes pending 5.9.0 release.

This reverts commits 918feb6..935d777 (PRs #85 and #108).