### PR TITLE
Update mbedtls configuration

### DIFF
--- a/source/mbedtls_thread_config.h
+++ b/source/mbedtls_thread_config.h
@@ -60,6 +60,9 @@
 /* Save ROM and a few bytes of RAM by specifying our own ciphersuite list */
 #define MBEDTLS_SSL_CIPHERSUITES MBEDTLS_TLS_ECJPAKE_WITH_AES_128_CCM_8
 
+/* Needed by SecureStore encrypt_decrypt_data */
+#define MBEDTLS_CIPHER_MODE_CTR
+
 /* Optimization. Remove all not needed stuff */
 /* For type TYPE_THREAD_SLEEPY_END_DEVICE
 #undef MBEDTLS_X509_USE_C
@@ -121,7 +124,6 @@
 #undef MBEDTLS_DEPRECATED_REMOVED
 #undef MBEDTLS_CAMELLIA_SMALL_MEMORY
 #undef MBEDTLS_CIPHER_MODE_CFB
-#undef MBEDTLS_CIPHER_MODE_CTR
 #undef MBEDTLS_CIPHER_NULL_CIPHER
 #undef MBEDTLS_CIPHER_PADDING_ONE_AND_ZEROS
 #undef MBEDTLS_CIPHER_PADDING_ZEROS_AND_LEN


### PR DESCRIPTION
Enable MBEDTLS_CIPHER_MODE_CTR as it is required by SecureStore.cpp