### PR TITLE
Configuration fixes for Wi-SUN

### DIFF
--- a/configs/Wisun_Stm_s2lp_RF.json
+++ b/configs/Wisun_Stm_s2lp_RF.json
@@ -27,9 +27,9 @@
         "backhaul-mac": "{0x02, 0x00, 0x00, 0x00, 0x00, 0x01}",
         "debug-trace": "false",
         "backhaul-dynamic-bootstrap": true,
-        "backhaul-prefix": "fd00:db8:ff1::",
-        "backhaul-default-route": "::/0",
-        "backhaul-next-hop": "fe80::1",
+        "backhaul-prefix": "\"fd00:db8:ff1::\"",
+        "backhaul-default-route": "\"::/0\"",
+        "backhaul-next-hop": "\"fe80::1\"",
         "multicast-addr": "ff05::7",
         "LED": "NC",
         "SERIAL_TX": "NC",
@@ -53,7 +53,8 @@
             "nanostack.configuration": "ws_border_router",
             "platform.stdio-convert-newlines": true,
             "platform.stdio-baud-rate": 115200,
-            "platform.stdio-buffered-serial": true
+            "platform.stdio-buffered-serial": true,
+            "mbed-mesh-api.use-malloc-for-heap": true
         },
         "K64F": {
             "kinetis-emac.tx-ring-len":4,


### PR DESCRIPTION
This fixes 2 issues with Wi-SUN config.
Escape characters were missing for parameters when using static border router.
mbed-mesh-api allocated static memory for heap causing too much memory used with IAR compilation