### PR TITLE
Allow compilation with non K64F/K66F boards

### DIFF
--- a/drivers/TARGET_MCUXpresso_MCUS/sal-nanostack-driver-k64f-eth.lib
+++ b/drivers/TARGET_MCUXpresso_MCUS/sal-nanostack-driver-k64f-eth.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/sal-nanostack-driver-k64f-eth/#b73d37cc229c595270baf50e83c80376e7c4a95d
+https://github.com/ARMmbed/sal-nanostack-driver-k64f-eth/#ffb13d8887945526f53020a92658ea1bc7d100fd

--- a/source/border_router_main.cpp
+++ b/source/border_router_main.cpp
@@ -167,7 +167,21 @@ void appl_info_trace(void)
     tr_info("Starting NanoStack Border Router...");
     tr_info("Build date: %s %s", __DATE__, __TIME__);
 #ifdef MBED_MAJOR_VERSION
-    tr_info("Mbed OS version: %d.%d.%d\n", MBED_MAJOR_VERSION, MBED_MINOR_VERSION, MBED_PATCH_VERSION);
+    tr_info("Mbed OS: %d", MBED_VERSION);
+#endif
+
+#if defined(MBED_SYS_STATS_ENABLED)
+    mbed_stats_sys_t stats;
+    mbed_stats_sys_get(&stats);
+
+    /* ARM = 1, GCC_ARM = 2, IAR = 3 */
+    tr_info("Compiler ID: %d", stats.compiler_id);
+    /* Compiler versions:
+       ARM: PVVbbbb (P = Major; VV = Minor; bbbb = build number)
+       GCC: VVRRPP  (VV = Version; RR = Revision; PP = Patch)
+       IAR: VRRRPPP (V = Version; RRR = Revision; PPP = Patch)
+    */
+    tr_info("Compiler Version: %d", stats.compiler_version);
 #endif
 }
 
@@ -175,7 +189,6 @@ void appl_info_trace(void)
  * \brief The entry point for this application.
  * Sets up the application and starts the border router module.
  */
-
 int main(int argc, char **argv)
 {
     ns_hal_init(app_stack_heap, APP_DEFINED_HEAP_SIZE, app_heap_error_handler, &heap_info);

--- a/source/mbedtls_thread_config.h
+++ b/source/mbedtls_thread_config.h
@@ -50,6 +50,7 @@
 
 /* Save RAM by adjusting to our exact needs */
 #define MBEDTLS_ECP_MAX_BITS             256
+#undef MBEDTLS_MPI_MAX_SIZE
 #define MBEDTLS_MPI_MAX_SIZE              32 // 256 bits is 32 bytes
 
 /* Save ROM and a few bytes of RAM by specifying our own ciphersuite list */


### PR DESCRIPTION
* sal-nanostack-driver-k64f-eth includes target specific header files that are not available for all targets.
Add target specific flags to k64f-eth-driver to allow builds for other targets.

* Fix IAR warning "incompatible redefinition of macro" 

* Add compiler stats to application

