### PR TITLE
Fix conflicting declarations of main() for GCC_ARM build with "-flto"

### DIFF
--- a/source/border_router_main.cpp
+++ b/source/border_router_main.cpp
@@ -227,7 +227,7 @@ void appl_info_trace(void)
  * \brief The entry point for this application.
  * Sets up the application and starts the border router module.
  */
-int main(int argc, char **argv)
+int main()
 {
     mbed_trace_init(); // set up the tracing library
     mbed_trace_print_function_set(trace_printer);


### PR DESCRIPTION
Update the main() to be compatible with the declaration from
platform/mbed_toolchain.h that adds the MBED_USED attribute.
Without the attribute the main() symbol is not emitted with the
GCC toolchain using "-Wl,--wrap,main" and "-flto" flags.

This patch is required by https://github.com/ARMmbed/mbed-os/pull/11856.