### PR TITLE
Added support for network encryption key (GTK) set to border router

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,6 @@ The Wi-SUN specific parameters are listed below.
 | `root-certificate`                  | Root certificate |
 | `own-certificate`                   | Own certificate |
 | `own-certificate-key`               | Own certificate's key |
-| `GTK0`               | Set GTK0 to predefined value for testing |
 
 Regulatory domain, operating class and operating mode are defined in the Wi-SUN PHY-specification.
 
@@ -305,6 +304,28 @@ After changing the radio shield, recompile the application.
 #### Wi-SUN RF shield
 
 Currently, only one radio shield, the STM S2LP radio shield, supports Wi-SUN.
+
+
+### Wi-SUN test configurations
+
+You can set the Border Router to fixed-channel mode by setting the channel function to fixed-channel, by defining the channel number and by setting the broadcast intervals:
+
+```
+        "uc-channel-function": 0,
+        "bc-channel-function": 0, 
+        "uc-fixed-channel": 11,
+        "bc-fixed-channel": 11,
+        "bc-dwell-interval": 255,
+        "bc-interval": 1020,
+```
+
+You can set the EAPOL group transient key (GTK) to a predefined value by setting the GTK0:
+
+```
+        "GTK0": "{0xBB, 0x06, 0x08, 0x57, 0x2C, 0xE1, 0x4D, 0x7B, 0xA2, 0xD1, 0x55, 0x49, 0x9C, 0xC8, 0x51, 0x9B}",
+```
+
+For the predefined GTK, the Wireshark IEEE 802.15.4 network decryption key can be calculated using SHA-256('Network name' || GTK0).
 
 ## File system support
 

--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ The Wi-SUN specific parameters are listed below.
 | `root-certificate`                  | Root certificate |
 | `own-certificate`                   | Own certificate |
 | `own-certificate-key`               | Own certificate's key |
+| `GTK0`               | Set GTK0 to predefined value for testing |
 
 Regulatory domain, operating class and operating mode are defined in the Wi-SUN PHY-specification.
 

--- a/source/borderrouter_ws.c
+++ b/source/borderrouter_ws.c
@@ -31,6 +31,9 @@
 #ifdef MBED_CONF_APP_CERTIFICATE_HEADER
 #include MBED_CONF_APP_CERTIFICATE_HEADER
 #endif
+#if defined(MBED_CONF_APP_GTK0)
+#include "net_ws_test.h"
+#endif
 
 #include "ns_trace.h"
 #define TRACE_GROUP "brro"
@@ -311,6 +314,17 @@ static int wisun_interface_up(void)
             return -1;
         }
     }
+
+#if defined(MBED_CONF_APP_GTK0)
+    uint8_t gtk0_value[16] = MBED_CONF_APP_GTK0;
+    uint8_t *gtks[4] = {gtk0_value, NULL, NULL, NULL};
+    ret = ws_test_gtk_set(ws_br_handler.ws_interface_id, gtks);
+    if (ret != 0) {
+        tr_error("Test GTK set failed %"PRIi32"", ret);
+        return -1;
+    }
+    tr_info("Test GTK set: %s", trace_array(gtk0_value, 16));
+#endif
 
 #if defined(MBED_CONF_APP_CERTIFICATE_HEADER)
     arm_certificate_chain_entry_s chain_info;


### PR DESCRIPTION
Setting enables to set GTK0 on border router to fixed value for testing purposes.