### PR TITLE
Update stm-spirit1-rf-driver

### DIFF
--- a/drivers/stm-spirit1-rf-driver.lib
+++ b/drivers/stm-spirit1-rf-driver.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/stm-spirit1-rf-driver/#b8e3da9b2999d1aec1e500d0acf6e725060d3515
+https://github.com/ARMmbed/stm-spirit1-rf-driver/#874f44bba39c9e7558be431111eac44005adf4fa


### PR DESCRIPTION
Removes use of deprecated APIs.

Needed for https://github.com/ARMmbed/mbed-os/pull/12142

Incorporates https://github.com/ARMmbed/stm-spirit1-rf-driver/pull/7, https://github.com/ARMmbed/stm-spirit1-rf-driver/pull/10 and https://github.com/ARMmbed/stm-spirit1-rf-driver/pull/11