### PR TITLE
Update stm-spirit1-rf-driver to mbed-os-5.15 branch

### DIFF
--- a/drivers/stm-spirit1-rf-driver.lib
+++ b/drivers/stm-spirit1-rf-driver.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/stm-spirit1-rf-driver/#b8e3da9b2999d1aec1e500d0acf6e725060d3515
+https://github.com/ARMmbed/stm-spirit1-rf-driver/#874f44bba39c9e7558be431111eac44005adf4fa


### PR DESCRIPTION
Update new Spirit RF driver to mbed-os-5.15 branch to allow compilation with the latest Mbed OS master branch.