### PR TITLE
Update sal-stack-nanostack-slip.lib to master

### DIFF
--- a/drivers/sal-stack-nanostack-slip.lib
+++ b/drivers/sal-stack-nanostack-slip.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/sal-stack-nanostack-slip/#b3a969bc474a3cf39c2c5720bf98f3d29170bc2b
+https://github.com/ARMmbed/sal-stack-nanostack-slip/#e0a405678f4f8db8c4dc30a647c21e3b6e88e9e3


### PR DESCRIPTION
Updated the sal stack nanostack slip lib to latest sha id

@artokin 