### PR TITLE
Update libraries in mbed-os-5.15 branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,8 +24,7 @@ def targets = [
 // Map toolchains to CI labels
 def toolchains = [
   ARM: "armc6",
-  GCC_ARM: "arm-none-eabi-gcc",
-  IAR: "iar_arm"
+  GCC_ARM: "arm-none-eabi-gcc"
   ]
 
 // Configurations

--- a/drivers/sal-stack-nanostack-slip.lib
+++ b/drivers/sal-stack-nanostack-slip.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/sal-stack-nanostack-slip/#b3a969bc474a3cf39c2c5720bf98f3d29170bc2b
+https://github.com/ARMmbed/sal-stack-nanostack-slip/#9e3472988a09c19cba5eaab9a99f344201873adc

--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#64853b354fa188bfe8dbd51e78771213c7ed37f7
+https://github.com/ARMmbed/mbed-os/#e642a7d8b3609a7c903e042cd772f00a5d299088


### PR DESCRIPTION
Update libraries in branch mbed-os-5.15.

- Use Slip driver that supports Mbed OS master (RawSerial replaced by UnbufferedSerial)
- Update Mbed OS version to mbed-os-5.15.2
- Remove IAR compilation from CI
