### PR TITLE
Add S2LP driver pin config to application

### DIFF
--- a/configs/Wisun_Stm_s2lp_RF.json
+++ b/configs/Wisun_Stm_s2lp_RF.json
@@ -83,6 +83,19 @@
         "K66F": {
             "kinetis-emac.tx-ring-len":4,
             "kinetis-emac.rx-ring-len":4
+        },
+        "MTB_STM_S2LP": {
+            "s2lp.SPI_SDI"  : "PA_7",
+            "s2lp.SPI_SDO"  : "PA_6",
+            "s2lp.SPI_SCLK" : "PA_5",
+            "s2lp.SPI_CS"   : "PC_0",
+            "s2lp.SPI_SDN"  : "PF_13",
+            "s2lp.SPI_GPIO0": "PA_3",
+            "s2lp.SPI_GPIO1": "PC_3",
+            "s2lp.SPI_GPIO2": "PF_3",
+            "s2lp.SPI_GPIO3": "PF_10",
+            "s2lp.I2C_SDA"  : "PB_7",
+            "s2lp.I2C_SCL"  : "PB_6"
         }
     }
 }

--- a/configs/Wisun_Stm_s2lp_RF_cell.json
+++ b/configs/Wisun_Stm_s2lp_RF_cell.json
@@ -95,6 +95,19 @@
         "K66F": {
             "kinetis-emac.tx-ring-len":4,
             "kinetis-emac.rx-ring-len":4
+        },
+        "MTB_STM_S2LP": {
+            "s2lp.SPI_SDI"  : "PA_7",
+            "s2lp.SPI_SDO"  : "PA_6",
+            "s2lp.SPI_SCLK" : "PA_5",
+            "s2lp.SPI_CS"   : "PC_0",
+            "s2lp.SPI_SDN"  : "PF_13",
+            "s2lp.SPI_GPIO0": "PA_3",
+            "s2lp.SPI_GPIO1": "PC_3",
+            "s2lp.SPI_GPIO2": "PF_3",
+            "s2lp.SPI_GPIO3": "PF_10",
+            "s2lp.I2C_SDA"  : "PB_7",
+            "s2lp.I2C_SCL"  : "PB_6"
         }
     }
 }

--- a/configs/Wisun_Stm_s2lp_RF_lab.json
+++ b/configs/Wisun_Stm_s2lp_RF_lab.json
@@ -83,6 +83,19 @@
         "K66F": {
             "kinetis-emac.tx-ring-len":4,
             "kinetis-emac.rx-ring-len":4
+        },
+        "MTB_STM_S2LP": {
+            "s2lp.SPI_SDI"  : "PA_7",
+            "s2lp.SPI_SDO"  : "PA_6",
+            "s2lp.SPI_SCLK" : "PA_5",
+            "s2lp.SPI_CS"   : "PC_0",
+            "s2lp.SPI_SDN"  : "PF_13",
+            "s2lp.SPI_GPIO0": "PA_3",
+            "s2lp.SPI_GPIO1": "PC_3",
+            "s2lp.SPI_GPIO2": "PF_3",
+            "s2lp.SPI_GPIO3": "PF_10",
+            "s2lp.I2C_SDA"  : "PB_7",
+            "s2lp.I2C_SCL"  : "PB_6"
         }
     }
 }


### PR DESCRIPTION
New S2LP driver does not provide PIN configuration for MTB_STM_S2LP
board. Define pins in the application configuration files.