### PR TITLE
Configuration for border router testing

### DIFF
--- a/configs/6lowpan_Atmel_RF.json
+++ b/configs/6lowpan_Atmel_RF.json
@@ -87,6 +87,19 @@
             "kinetis-emac.tx-ring-len":4,
             "kinetis-emac.rx-ring-len":4
         },
+        "K64F_STATIC_BR": {
+            "LED": "LED_GREEN",
+            "SERIAL_TX": "PTE0",
+            "SERIAL_RX": "PTE1",
+            "SERIAL_CTS": "PTE2",
+            "SERIAL_RTS": "PTE3",
+            "kinetis-emac.tx-ring-len":4,
+            "kinetis-emac.rx-ring-len":4,
+            "debug-trace": "true",
+            "pan-id": "0xABBA",
+            "rf-channel": 17,
+            "mbed-mesh-api.heap-size": 100000
+        },
         "K66F": {
             "LED": "LED_GREEN",
             "kinetis-emac.tx-ring-len":4,

--- a/configs/Thread_Atmel_RF.json
+++ b/configs/Thread_Atmel_RF.json
@@ -75,6 +75,19 @@
             "LED": "LED_GREEN",
             "kinetis-emac.tx-ring-len":4,
             "kinetis-emac.rx-ring-len":4
+        },
+        "K64F_STATIC_BR": {
+            "LED": "LED_GREEN",
+            "SERIAL_TX": "PTE0",
+            "SERIAL_RX": "PTE1",
+            "SERIAL_CTS": "PTE2",
+            "SERIAL_RTS": "PTE3",
+            "kinetis-emac.tx-ring-len":4,
+            "kinetis-emac.rx-ring-len":4,
+            "rf-channel": 26,
+            "debug-trace": true,
+            "pan-id": "0xBAAB",
+            "mbed-mesh-api.heap-size": 100000
         }
     }
 }

--- a/configs/Wisun_Stm_s2lp_RF.json
+++ b/configs/Wisun_Stm_s2lp_RF.json
@@ -83,6 +83,16 @@
         "K66F": {
             "kinetis-emac.tx-ring-len":4,
             "kinetis-emac.rx-ring-len":4
+        },
+        "K64F_STATIC_BR": {
+            "kinetis-emac.tx-ring-len":4,
+            "kinetis-emac.rx-ring-len":4,
+            "network-name": "\"ARM-WS-LAB-NWK\"",
+            "mbed-mesh-api.heap-size": 100000
+        },
+        "DISCO_F769NI_STATIC_BR": {
+            "network-name": "\"ARM-WS-LAB-NWK\"",
+            "mbed-mesh-api.heap-size": 100000
         }
     }
 }

--- a/custom_targets.json
+++ b/custom_targets.json
@@ -1,0 +1,8 @@
+{
+    "DISCO_F769NI_STATIC_BR": {
+        "inherits"                          : ["DISCO_F769NI"]
+    },
+    "K64F_STATIC_BR": {
+        "inherits"                          : ["K64F"]
+    }
+}


### PR DESCRIPTION
Create configurations for border router testing.
Testable border routers can be compiled using targets:
 -K64F_STATIC_BR
 -DISCO_F769NI_STATIC_BR